### PR TITLE
remove the ugly segfault when no arguments is provided

### DIFF
--- a/brainfuck-interpreter.c
+++ b/brainfuck-interpreter.c
@@ -16,7 +16,7 @@ static void usage(void)
 int main(int argc, char **argv)
 {
     int ch;
-    FILE *fd;
+    FILE *fd = NULL;
     size_t fsize;
     char *buffer;
 
@@ -37,6 +37,8 @@ int main(int argc, char **argv)
                 usage();
         }
     }
+    if (fd == NULL)
+	    usage();
 
     /* Get file size. */
     if (fseek(fd, 0L, SEEK_END) != 0)


### PR DESCRIPTION
This is not a bug but it’s quiet embarrassing to segfault when the user simply forgot to use the `-f` option. It would be better to call the usage function in this case